### PR TITLE
Re-initialize LEDs after receiving a new config

### DIFF
--- a/MIDI_Commander_Custom/USB_DEVICE/App/usbd_midi_if.c
+++ b/MIDI_Commander_Custom/USB_DEVICE/App/usbd_midi_if.c
@@ -8,6 +8,7 @@
 #include "midi_defines.h"
 #include "flash_midi_settings.h"
 #include "midi_cmds.h"
+#include "switch_router.h"
 #include <string.h>
 
 extern I2C_HandleTypeDef hi2c1;
@@ -130,6 +131,11 @@ void process_sysex_message(void){
 	case SYSEX_CMD_WRITE_FLASH:
 		// TODO: check data length
 		sysex_write_flash(&(pSysexHead->start_parameters));
+		/*
+		 * Init LEDs after receiving the new config to reset LEDs to the off state and
+		 * re-read from the new config which LEDs should have a toggle behavior.
+		 */
+		sw_led_init();
 		break;
 	case SYSEX_CMD_RESET:
 		NVIC_SystemReset();


### PR DESCRIPTION
Hello there,

As I was experimenting with different configurations I noticed that LEDs were not toggling despite the config saying they should. It turned out we're missing a re-initialization of the LEDs after receiving a new config so that we set which LEDs need to have the toggle behavior. Here's a small patch that fixes it.

Cheers!