### PR TITLE
Topic/more commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ Mkfile.old
 dkms.conf
 
 .metadata
+
+# macOS Finder metadata
+.DS_Store

--- a/MIDI_Commander_Custom/Core/Inc/flash_midi_settings.h
+++ b/MIDI_Commander_Custom/Core/Inc/flash_midi_settings.h
@@ -16,7 +16,7 @@ extern uint8_t *pBankStrings;
 
 
 #define MIDI_ROM_CMD_SIZE	(4)
-#define MIDI_NUM_COMMANDS_PER_SWITCH (3)
+#define MIDI_NUM_COMMANDS_PER_SWITCH (10)
 #define MIDI_ROM_KEY_STRIDE	(MIDI_NUM_COMMANDS_PER_SWITCH*MIDI_ROM_CMD_SIZE)
 
 void flash_settings_erase(void);

--- a/MIDI_Commander_Custom/Core/Inc/flash_midi_settings.h
+++ b/MIDI_Commander_Custom/Core/Inc/flash_midi_settings.h
@@ -16,7 +16,8 @@ extern uint8_t *pBankStrings;
 
 
 #define MIDI_ROM_CMD_SIZE	(4)
-#define MIDI_ROM_KEY_STRIDE	(3*MIDI_ROM_CMD_SIZE)
+#define MIDI_NUM_COMMANDS_PER_SWITCH (3)
+#define MIDI_ROM_KEY_STRIDE	(MIDI_NUM_COMMANDS_PER_SWITCH*MIDI_ROM_CMD_SIZE)
 
 void flash_settings_erase(void);
 void flash_settings_write(uint8_t* data, uint32_t offset);

--- a/MIDI_Commander_Custom/Core/Inc/main.h
+++ b/MIDI_Commander_Custom/Core/Inc/main.h
@@ -52,6 +52,7 @@ extern "C" {
 
 /* Exported functions prototypes ---------------------------------------------*/
 void Error_Handler(void);
+void Error(char *msg);
 
 /* USER CODE BEGIN EFP */
 

--- a/MIDI_Commander_Custom/Core/Inc/midi_cmds.h
+++ b/MIDI_Commander_Custom/Core/Inc/midi_cmds.h
@@ -8,6 +8,10 @@
 #ifndef INC_MIDI_CMDS_H_
 #define INC_MIDI_CMDS_H_
 
+#include <stdint.h>
+
+#define ERROR_BUFFERS_FULL (-1)
+
 //void sendMidiCC(uint8_t channel, uint8_t controller_number, uint8_t controller_value);
 
 int8_t midiCmd_send_pc_command_from_rom(uint8_t *pRom);

--- a/MIDI_Commander_Custom/Core/Src/flash_midi_settings.c
+++ b/MIDI_Commander_Custom/Core/Src/flash_midi_settings.c
@@ -12,7 +12,7 @@
 #define FLASH_SETTINGS_OFFSET	(1024*128)
 #define FLASH_SETTINGS_START	(FLASH_BASE + FLASH_SETTINGS_OFFSET)
 
-#define FLASH_SETTINGS_NO_PAGES	(1)
+#define FLASH_SETTINGS_NO_PAGES	(3)
 
 uint8_t *pGlobalSettings = (uint8_t*)FLASH_SETTINGS_START;
 uint8_t *pBankStrings = (uint8_t*)FLASH_SETTINGS_START+32;
@@ -40,7 +40,7 @@ void flash_settings_erase(void){
 
 	if(status != HAL_OK){
 		// TODO: Display a message of the page that's in error
-		Error_Handler();
+		Error("Flash erase error");
 	}
 
 }
@@ -56,8 +56,7 @@ void flash_settings_write(uint8_t* data, uint32_t offset){
 		uint16_t write_data = data[2*i] + (data[2*i+1] << 8);
 		HAL_StatusTypeDef status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_HALFWORD, flash_address + 2*i, write_data);
 		if(status != HAL_OK){
-			// TODO: Display flash write error
-			Error_Handler();
+			Error("Flash write error");
 		}
 	}
 

--- a/MIDI_Commander_Custom/Core/Src/main.c
+++ b/MIDI_Commander_Custom/Core/Src/main.c
@@ -105,24 +105,30 @@ int main(void)
 
   /* Initialize all configured peripherals */
   MX_GPIO_Init();
+
   MX_DMA_Init();
   MX_USART2_UART_Init();
   MX_I2C1_Init();
+
   MX_USB_DEVICE_Init();
   /* USER CODE BEGIN 2 */
 
   // Reset the USB interface in case it's still plugged in.
   HAL_GPIO_WritePin(USB_ID_GPIO_Port, USB_ID_Pin, GPIO_PIN_RESET);
 
-  // Check we've got a 512kB device, in case Melo switch to a smaller device at some point
+  display_init();
+
+  // Check we've got a 256kB device, in case Melo switch to a smaller device at some point
   uint16_t flash_size = (*(uint16_t*)FLASHSIZE_BASE);
-  if(flash_size < 512){
-	  Error_Handler();
+  uint16_t min_size = 256;
+  if(flash_size < min_size) {
+	  char msg[25];
+	  sprintf(msg, "Mem %3dkb < %3dkb", flash_size, min_size);
+	  Error(msg);
   }
 
-
-  display_init();
   display_setConfigName();
+
   sw_led_init();
 
   HAL_Delay(1000);
@@ -362,6 +368,24 @@ void Error_Handler(void)
   {
   }
   /* USER CODE END Error_Handler_Debug */
+}
+
+/*
+ * @brief This function can be called to display an error message on the screen,
+ * if the display is on, before calling Error_Handler() to stop all operations.
+ */
+void Error(char *msg) {
+	if (ssd1306_GetDisplayOn() == 0) {
+		/* Display is on */
+		ssd1306_Fill(Black);
+		ssd1306_SetCursor(2, 0);
+		ssd1306_WriteString("Error:", Font_6x8, White);
+		ssd1306_SetCursor(2, 9);
+		ssd1306_WriteString(msg, Font_6x8, White);
+		ssd1306_UpdateScreen();
+	}
+
+	Error_Handler();
 }
 
 #ifdef  USE_FULL_ASSERT

--- a/MIDI_Commander_Custom/Core/Src/midi_cmds.c
+++ b/MIDI_Commander_Custom/Core/Src/midi_cmds.c
@@ -4,7 +4,9 @@
  *  Created on: Jul 6, 2021
  *      Author: D Harvie
  */
+#include "midi_cmds.h"
 #include "main.h"
+#include "flash_midi_settings.h"
 #include "midi_defines.h"
 #include "usbd_midi_if.h"
 #include "ssd1306.h"
@@ -21,11 +23,11 @@ uint8_t midi_usb_assembly_buffer[16];
  *
  * Because the midi serial port is relatively slow (compared to USB) and it has no inherent buffering in the stack beyond
  * the DMA transfer that is started, we're defining a series of "mailbox" type buffers that will be sent when something is
- * written to them.
+ * written to them. Since each push of a switch can potentially send MIDI_NUM_COMMANDS_PER_SWITCH commands as well as another
+ * MIDI_NUM_COMMANDS_PER_SWITCH commands if not in toggle mode, then we need 2 * MIDI_NUM_COMMANDS_PER_SWITCH buffers.
  */
-#define NO_BUFFERS (4)
+#define NO_BUFFERS (2 * MIDI_NUM_COMMANDS_PER_SWITCH)
 #define BUFFER_SIZE (16)
-#define ERROR_BUFFERS_FULL (-1)
 
 // Implementing as a series of buffers
 uint8_t midi_uart_out_buffer[NO_BUFFERS][BUFFER_SIZE];
@@ -35,7 +37,7 @@ uint8_t last_transmitted_buffer = NO_BUFFERS -1; // When a buffer is given to th
 // Note should only be called from critical section, not thread safe
 static int8_t get_next_available_tx_buffer(void){
 	// Starting at the last sent buffer, loop through and find the next available.
-	for(int i=0; i<4; i++){
+	for(int i=0; i<NO_BUFFERS; i++){
 		uint8_t n = (last_transmitted_buffer + i + 1) % NO_BUFFERS;
 		if(midi_uart_out_buffer_bytes_to_tx[n] == 0){
 			return n;
@@ -60,7 +62,7 @@ uint32_t midiCmd_get_delay(uint8_t *pRom){
 void midi_serial_start_next_dma(void){
 	uint8_t buffer_to_transmit = 0xFF;
 	// Find the next buffer ready for transmit
-	for(int i=0; i<4; i++){
+	for(int i=0; i<NO_BUFFERS; i++){
 		uint8_t n = (last_transmitted_buffer + i + 1) % NO_BUFFERS;
 		if(midi_uart_out_buffer_bytes_to_tx[n] != 0){
 			buffer_to_transmit = n;
@@ -68,11 +70,10 @@ void midi_serial_start_next_dma(void){
 		}
 	}
 
-	if(buffer_to_transmit < 4){
+	if(buffer_to_transmit < NO_BUFFERS){
 		// We've found a valid buffer to transmit
 		while(HAL_UART_Transmit_DMA(&huart2, midi_uart_out_buffer[buffer_to_transmit],
-				midi_uart_out_buffer_bytes_to_tx[buffer_to_transmit]) != HAL_OK)
-			;
+				midi_uart_out_buffer_bytes_to_tx[buffer_to_transmit]) != HAL_OK);
 		last_transmitted_buffer = buffer_to_transmit;
 	}
 
@@ -276,7 +277,10 @@ int8_t midiCmd_send_cc_command_from_rom(uint8_t *pRom, uint8_t on_off){
 	/*
 	 * Displaying messages on screen likely involves a delay which can be
 	 * detrimental on the timing of MIDI messages. So keep this commented and
-	 * only use for debugging.
+	 * only use for debugging. Using the display here also hides issues with
+	 * the serial transmission buffers. The delay in the display update allows
+	 * serial transmission to finish before the next time we enter this function.
+	 * So we never use multiple buffers at the same time and this can hide issues.
 	 */
 //	ssd1306_SetCursor(2, 10);
 //	char msg[25];

--- a/MIDI_Commander_Custom/Core/Src/switch_router.c
+++ b/MIDI_Commander_Custom/Core/Src/switch_router.c
@@ -122,7 +122,7 @@ void sw_led_init(void){
 			// Clear the toggle bit
 			a_sw_obj[sw].led_cmd_toggle &= ~(1<<page);
 
-			for(int cmd=0; cmd<3; cmd++){
+			for(int cmd=0; cmd<MIDI_NUM_COMMANDS_PER_SWITCH; cmd++){
 				uint8_t *pCmd = getRomPointer(page, sw, cmd);
 				if(midiCmd_get_cmd_toggle(pCmd)){
 					a_sw_obj[sw].led_cmd_toggle |= (1<<page);
@@ -301,7 +301,7 @@ void handleSwitches(void){
 						setLed(i,SET);
 					}
 
-					for(int j=0; j<3; j++){
+					for(int j=0; j<MIDI_NUM_COMMANDS_PER_SWITCH; j++){
 						handleCmdSwDown(pSwitchCmds + (MIDI_ROM_KEY_STRIDE * (i + switch_current_page*8)) + (MIDI_ROM_CMD_SIZE * j),
 								get_sw_toggle_stage(&a_sw_obj[i]));
 					}
@@ -312,7 +312,7 @@ void handleSwitches(void){
 						setLed(i, RESET);
 					}
 
-					for(int j=0; j<3; j++){
+					for(int j=0; j<MIDI_NUM_COMMANDS_PER_SWITCH; j++){
 						handleCmdSwUp(pSwitchCmds + (MIDI_ROM_KEY_STRIDE * (i + switch_current_page*8)) + (MIDI_ROM_CMD_SIZE * j),
 								get_sw_toggle_stage(&a_sw_obj[i]));
 					}

--- a/MIDI_Commander_Custom/Core/Src/switch_router.c
+++ b/MIDI_Commander_Custom/Core/Src/switch_router.c
@@ -188,24 +188,29 @@ void setCmdDurationDelay(uint8_t *pRom){
 }
 
 void handleCmdSwDown(uint8_t *pRom, uint8_t toggleState){
+	/*
+	 * Assume success by default since this was the behavior before adding this status.
+	 */
+	int8_t status = 0;
+
 	switch(*pRom & 0xF0){
 	case CMD_PC_NIBBLE:
-		midiCmd_send_pc_command_from_rom(pRom);
+		status = midiCmd_send_pc_command_from_rom(pRom);
 		break;
 	case CMD_CC_NIBBLE:
 		if(midiCmd_get_cmd_toggle(pRom)){
-			midiCmd_send_cc_command_from_rom(pRom, toggleState);
+			status = midiCmd_send_cc_command_from_rom(pRom, toggleState);
 		} else {
 			// Not toggling, so set command and either set a duration or not
-			midiCmd_send_cc_command_from_rom(pRom, MIDI_CONTROL_ON);
+			status = midiCmd_send_cc_command_from_rom(pRom, MIDI_CONTROL_ON);
 		}
 		break;
 	case CMD_PB_NIBBLE:
 		if(midiCmd_get_cmd_toggle(pRom)){
-			midiCmd_send_pb_command_from_rom(pRom, toggleState);
+			status = midiCmd_send_pb_command_from_rom(pRom, toggleState);
 		} else {
 			// Not toggling, so set command and either set a duration or not
-			midiCmd_send_pb_command_from_rom(pRom, MIDI_CONTROL_ON);
+			status = midiCmd_send_pb_command_from_rom(pRom, MIDI_CONTROL_ON);
 			if(midiCmd_get_delay(pRom) != 0){
 				setCmdDurationDelay(pRom);
 			}
@@ -213,48 +218,57 @@ void handleCmdSwDown(uint8_t *pRom, uint8_t toggleState){
 		break;
 	case CMD_NOTE_NIBBLE:
 		if(midiCmd_get_cmd_toggle(pRom)){
-			midiCmd_send_note_command_from_rom(pRom, toggleState);
+			status = midiCmd_send_note_command_from_rom(pRom, toggleState);
 		} else {
 			// Not toggling, so set command and either set a duration or not
-			midiCmd_send_note_command_from_rom(pRom, MIDI_CONTROL_ON);
+			status = midiCmd_send_note_command_from_rom(pRom, MIDI_CONTROL_ON);
 			if(midiCmd_get_delay(pRom) != 0){
 				setCmdDurationDelay(pRom);
 			}
 		}
 		break;
 	case CMD_START_NIBBLE:
-		midiCmd_send_start_command();
+		status = midiCmd_send_start_command();
 		break;
 	case CMD_STOP_NIBBLE:
-		midiCmd_send_stop_command();
+		status = midiCmd_send_stop_command();
 		break;
 	default:
 		break;
 	}
+
+	if (status == ERROR_BUFFERS_FULL) {
+		Error("Buffers full");
+ 	}
 }
 
 void handleCmdSwUp(uint8_t *pRom, uint8_t toggleState){
+	/*
+	 * Assume success by default since this was the behavior before adding this status.
+	 */
+	int8_t status = 0;
+
 	switch(*pRom & 0xF0){
 	case CMD_PC_NIBBLE:
 		break;
 	case CMD_CC_NIBBLE:
 		if(!midiCmd_get_cmd_toggle(pRom)){
-			midiCmd_send_cc_command_from_rom(pRom, MIDI_CONTROL_OFF);
+			status = midiCmd_send_cc_command_from_rom(pRom, MIDI_CONTROL_OFF);
 		}
 		break;
 	case CMD_PB_NIBBLE:
-		if(!midiCmd_get_cmd_toggle(pRom)){
-			if(midiCmd_get_delay(pRom) == 0){
+		if(!midiCmd_get_cmd_toggle(pRom)) {
+			if(midiCmd_get_delay(pRom) == 0) {
 				// No cmd duration delay, so immediately release
-				midiCmd_send_pb_command_from_rom(pRom, MIDI_CONTROL_OFF);
+				status = midiCmd_send_pb_command_from_rom(pRom, MIDI_CONTROL_OFF);
 			}
 		}
 		break;
 	case CMD_NOTE_NIBBLE:
-		if(!midiCmd_get_cmd_toggle(pRom)){
-			if(midiCmd_get_delay(pRom) == 0){
+		if(!midiCmd_get_cmd_toggle(pRom)) {
+			if(midiCmd_get_delay(pRom) == 0) {
 				// No cmd duration delay, so immediately release
-				midiCmd_send_note_command_from_rom(pRom, MIDI_CONTROL_OFF);
+				status = midiCmd_send_note_command_from_rom(pRom, MIDI_CONTROL_OFF);
 			}
 		}
 		break;
@@ -265,6 +279,10 @@ void handleCmdSwUp(uint8_t *pRom, uint8_t toggleState){
 	default:
 		break;
 	}
+
+	if (status == ERROR_BUFFERS_FULL) {
+		Error("Buffers full");
+ 	}
 }
 
 void setLed(uint8_t sw_no, uint8_t state){

--- a/MIDI_Commander_Custom/STM32F103RETX_FLASH.ld
+++ b/MIDI_Commander_Custom/STM32F103RETX_FLASH.ld
@@ -38,7 +38,7 @@ _Min_Stack_Size = 0x400 ;	/* required amount of stack */
 MEMORY
 {
   RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 64K
-  FLASH    (rx)    : ORIGIN = 0x8000000,   LENGTH = 512K
+  FLASH    (rx)    : ORIGIN = 0x8000000,   LENGTH = 256K
 }
 
 

--- a/MIDI_Commander_Custom/STM32F103RETX_FLASH_DFU.ld
+++ b/MIDI_Commander_Custom/STM32F103RETX_FLASH_DFU.ld
@@ -37,7 +37,7 @@ _Min_Stack_Size = 0x400 ;	/* required amount of stack */
 MEMORY
 {
   RAM    (xrw)    : ORIGIN = 0x20000000,   LENGTH = 64K
-  FLASH    (rx)    : ORIGIN = (0x8000000 + 0x3000),   LENGTH = (512K - 0x3000)
+  FLASH    (rx)    : ORIGIN = (0x8000000 + 0x3000),   LENGTH = (256K - 0x3000)
 }
 
 

--- a/python/CSV_to_Flash.py
+++ b/python/CSV_to_Flash.py
@@ -109,3 +109,8 @@ for x in range(0, no_chunks):
 
 
 print('Finshed, reseting device...')
+outmsg = mido.Message('sysex', data=[MIDI_MANUF_ID, SYSEX_CMD_RESET])
+outport.send(outmsg)
+
+inport.close()
+outport.close()

--- a/python/CSV_to_Flash.py
+++ b/python/CSV_to_Flash.py
@@ -6,12 +6,20 @@ import lib.settingsBinaryPacker as sbp
 import sys
 import mido
 import time
+from math import ceil
 
 MIDI_MANUF_ID = 0x7D
 
 ERASE_FLASH = 52
 WRITE_FLASH = 54
-SYSEX_CMD_RESET	= 60
+SYSEX_CMD_RESET = 60
+
+# Flash pages are 1kByte
+FLASH_PAGE_SIZE = 1024
+
+# This needs to be in sync with flash_midi_settings.c where a number of flash
+# pages to manage is hard-coded
+ALLOWED_NUM_FLASH_PAGES = 3
 
 midi_inputs = [x for x in mido.get_input_names() if 'STM' in x]
 midi_outputs = [x for x in mido.get_output_names() if 'STM' in x]
@@ -36,7 +44,7 @@ def remove_comments(content):
         if "#" not in l:
             no_comments.append(l)
     return no_comments
-        
+
 no_comments = remove_comments(raw_content)
 
 # Split into individual table sections
@@ -57,7 +65,7 @@ for i,tline in enumerate(title_lines):
     df = pd.read_csv(io.StringIO('\n'.join(frame_lines)), delimiter=',').dropna(how='all')
     df.drop(df.columns[df.columns.str.contains('unnamed',case = False)],axis = 1, inplace=True)
     df_dic[tline[0].strip()] = df
-    
+
 # Setup the columns in the Button_Settings table
 df_dic['Button_Settings'].set_index(['Bank_Number','Button_Identifier'], inplace=True)
 df_dic['Global_Settings'].set_index(['Label'], inplace=True)
@@ -72,11 +80,25 @@ for index, row in df_dic['Button_Settings'].iterrows():
 
 flash_contents = bytes(memory_bytes_list)
 
+content_size = len(flash_contents)
+print(f"Flash content is {content_size} bytes = {content_size / 1024} kB")
+
+actual_num_flash_pages = ceil(content_size / FLASH_PAGE_SIZE)
+if actual_num_flash_pages > ALLOWED_NUM_FLASH_PAGES:
+    print(
+        f"WARNING: Your configuration requires {actual_num_flash_pages} "
+        f"flash pages which is more than the {ALLOWED_NUM_FLASH_PAGES} pages "
+        "allowed")
+
+ans = input("Continue? (y/N) ").lower().strip()
+
+if ans != "y":
+    sys.exit(1)
+
 # File is now converted to a byte array, this will be loaded to the flash.
 
 inport = mido.open_input(midi_inputs[0])
 outport = mido.open_output(midi_outputs[0])
-
 
 # Erase Flash settings pages
 print('Erasing Flash Settings')
@@ -92,13 +114,12 @@ print('Erase Complete')
 no_chunks = int(len(flash_contents)/16)
 for x in range(0, no_chunks):
     print('Writing Flash Chunk: ', x+1, '/', no_chunks)
-    
+
     flash_chunk_low_byte = x & 0x7F
     flash_chunk_high_byte = (x >> 7) & 0x7F
-    
+
     outmsg = mido.Message('sysex', data=[MIDI_MANUF_ID, WRITE_FLASH, flash_chunk_high_byte, flash_chunk_low_byte])
-    
-    
+
     for i in range(0, 16):
         outmsg.data += [flash_contents[x*16 + i] >> 4]
         outmsg.data += [flash_contents[x*16 + i] & 0xF]

--- a/python/lib/cmdBinaryPacker.py
+++ b/python/lib/cmdBinaryPacker.py
@@ -1,3 +1,4 @@
+MIDI_NUM_COMMANDS_PER_SWITCH = 3
 
 CMD_NO_CMD_NIBBLE = 0x00
 CMD_PC_NIBBLE = 0xC0
@@ -107,24 +108,13 @@ def remove_prefix(text, prefix):
     return text
 
 def pack_row(row):
-    
-    cmd_A = row.loc[row.index.str.startswith('A_')]
-    cmd_A.index = cmd_A.index.str.replace('A_','')
-    func_A = cmd_route_table.get(cmd_A['CommandType'], cmd_none)
-    
-    cmd_B = row.loc[row.index.str.startswith('B_')]
-    cmd_B.index = cmd_B.index.str.replace('B_','')
-    func_B = cmd_route_table.get(cmd_B['CommandType'], cmd_none)
-    
-    cmd_C = row.loc[row.index.str.startswith('C_')]
-    cmd_C.index = cmd_C.index.str.replace('C_','')
-    func_C = cmd_route_table.get(cmd_C['CommandType'], cmd_none)
-    
-    row_byte_list = func_A(cmd_A)
-    row_byte_list += func_B(cmd_B)
-    row_byte_list += func_C(cmd_C)
+    row_byte_list = []
+    for i in range(0, MIDI_NUM_COMMANDS_PER_SWITCH):
+        cmd_prefix = f"{chr(ord('A') + i)}_"
+        cmd = row.loc[row.index.str.startswith(cmd_prefix)]
+        cmd.index = cmd.index.str.replace(cmd_prefix, '')
+        func = cmd_route_table.get(cmd['CommandType'], cmd_none)
+        cmd_byte_list = func(cmd)
+        row_byte_list += cmd_byte_list
 
     return row_byte_list
-
-
-    

--- a/python/lib/cmdBinaryPacker.py
+++ b/python/lib/cmdBinaryPacker.py
@@ -1,4 +1,4 @@
-MIDI_NUM_COMMANDS_PER_SWITCH = 3
+MIDI_NUM_COMMANDS_PER_SWITCH = 10
 
 CMD_NO_CMD_NIBBLE = 0x00
 CMD_PC_NIBBLE = 0xC0
@@ -30,14 +30,14 @@ def cmd_pc(cmd):
         bank_select_high = (int(cmd['BankSelect_(PC)']) >> 7) & 0x7F
     else:
         bank_select_high = 0x80
-    
+
     cmd_bytes = [
         CMD_PC_NIBBLE | int(cmd['Channel_(PC/CC/Note/PB)'] - 1), # Command and channel
         int(cmd['Number_(PC/CC/Note)']) & 0x7F, # Patch number
         bank_select_high,
         bank_select_low
         ]
-    
+
     return cmd_bytes
 
 
@@ -61,20 +61,20 @@ def cmd_note(cmd):
         int(cmd['Duration_(Note/PB)']) & 0x7F
         ]
     return cmd_bytes
-    
-    
+
+
 def cmd_pb(cmd):
     # The pitch in the CSV file will be -8192 to 8191, this needs to be centered
     # around 0x2000
-    
+
     if -8192 > cmd['OnValue_(CC/PB)'] > 8191:
         raise ValueError('PB outside of range: ', cmd['OnValue_(CC/PB)'])
-    
+
     pitch = int(cmd['OnValue_(CC/PB)'] + 0x2000)
-    
+
     pitch_LSB = pitch & 0x7F
-    pitch_MSB = (pitch >> 7) & 0x7F 
-    
+    pitch_MSB = (pitch >> 7) & 0x7F
+
     cmd_bytes = [
         CMD_PB_NIBBLE | int(cmd['Channel_(PC/CC/Note/PB)'] - 1), # Command and channel
         pitch_LSB | get_toggle_bit(cmd['Toggle_(CC/PB/Note)']), # high byte of value & toggle
@@ -87,11 +87,14 @@ def cmd_pb(cmd):
 def cmd_start(cmd):
     return [CMD_START_NIBBLE, 0, 0, 0]
 
+
 def cmd_stop(cmd):
     return [CMD_STOP_NIBBLE, 0, 0, 0]
 
+
 def cmd_none(cmd):
     return [0,0,0,0]
+
 
 cmd_route_table = {
     'PC': cmd_pc,
@@ -102,10 +105,12 @@ cmd_route_table = {
     'Stop':cmd_stop
     }
 
+
 def remove_prefix(text, prefix):
     if text.startswith(prefix):
         return text[len(prefix):]
     return text
+
 
 def pack_row(row):
     row_byte_list = []

--- a/python/lib/settingsBinaryPacker.py
+++ b/python/lib/settingsBinaryPacker.py
@@ -1,23 +1,34 @@
-
 GLOBAL_SETTINGS_CHANNEL = 0
 GLOBAL_SETTINGS_REALTIME_PASS = 1
 
+
 def pack_global_settings(df):
-    bin_list = [0] * 16 # global settings will be 32 bytes long (bit of pluck as to how much is needed out of the 128 bytes)
-    bin_list[GLOBAL_SETTINGS_CHANNEL] = int(df.loc['MIDI_Channel','Value']) & 0xF
-    if 'Y' in df.loc['RealTime_Passthrough','Value']:
+    # global settings will be 32 bytes long (bit of pluck as to how much is
+    # needed out of the 128 bytes)
+    bin_list = [0] * 16
+    bin_list[GLOBAL_SETTINGS_CHANNEL] = \
+        int(df.loc['MIDI_Channel', 'Value']) & 0xF
+    if 'Y' in df.loc['RealTime_Passthrough', 'Value']:
         bin_list[GLOBAL_SETTINGS_REALTIME_PASS] = 0x1
-    #print('{:8.8}'.format(df.loc['ConfigName'].Value))
+    # print('{:8.8}'.format(df.loc['ConfigName'].Value))
     bin_list += ('{:16.16}'.format(df.loc['ConfigName'].Value)).encode('ASCII')
 
-    
     return bin_list
+
 
 def pack_bank_strings(df):
     bin_list = []
     for index, row in df.iterrows():
-        # Pack the 4 byte name
-        bin_list += ('{:4.4}'.format(row['Bank_Name_Large'])).encode('ASCII')
-        bin_list += ('{:8.8}'.format(row['Bank_Info_Small'])).encode('ASCII')
-        
+        # Pack the bank info. The large name is 4 bytes and the small string is
+        # 8 bytes. In case of an empty string, the value read from the CSV is
+        # nan.
+        large_name = str(row['Bank_Name_Large'])
+        small_name = str(row['Bank_Info_Small'])
+        if large_name == 'nan':
+            large_name = ''
+        if small_name == 'nan':
+            small_name = ''
+        bin_list += ('{:4.4}'.format(large_name)).encode('ASCII')
+        bin_list += ('{:8.8}'.format(small_name)).encode('ASCII')
+
     return bin_list


### PR DESCRIPTION
This provides a first solution for issue #12 making the number of commands per switch configurable.

With this it should be sufficient to update the `MIDI_NUM_COMMANDS_PER_SWITCH` constant in `flash_midi_settings.h` and in `python/lib/cmdBinaryPacker.py`.

The patches currently bump the number of commands to 10. That required extending the config from 1 flash page to 3. If the config grows more, then the number of flash pages need to be updated in `flash_midi_settings.c` and in `python/lib/cmdBinaryPacker.py`.